### PR TITLE
Set default values when running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ local ETS table for fast access.
 The Fly.io platform already provides and ENV value of `FLY_REGION` which this library accesses.
 
 ```elixir
+Fly.running_in_fly?()
+#=> true
+
 Fly.primary_region()
 #=> "syd"
 
@@ -95,13 +98,7 @@ Fly.rpc_primary(String, :upcase, ["fly"])
 
 ## Local Development
 
-When doing local development, without updating some settings, you will see an error like:
-
-```
-(ArgumentError) could not fetch environment variable "PRIMARY_REGION" because it is not set
-```
-
-There are 2 ENV values that need to be set for local development work.
+When doing local development, the local and primary regions will be set to "local". However, if you want to simulate running in Fly.io locally, you can set the `FLY_REGION` and `PRIMARY_REGION` environment variables:
 
 - `FLY_REGION` - Fly.io tells you which region your app is running in.
 - `PRIMARY_REGION` - You tell Fly.io which region is your "primary".

--- a/lib/fly.ex
+++ b/lib/fly.ex
@@ -5,12 +5,24 @@ defmodule Fly do
   """
 
   @doc """
+  Returns true if currently running on Fly.io
+  """
+  @spec running_in_fly?() :: boolean()
+  def running_in_fly?() do
+    System.fetch_env("FLY_REGION") != :error
+  end
+
+  @doc """
   Return the configured primary region. Reads and requires an ENV setting for
   `PRIMARY_REGION`.
   """
   @spec primary_region() :: String.t()
   def primary_region do
-    System.fetch_env!("PRIMARY_REGION")
+    if running_in_fly?() do
+      System.fetch_env!("PRIMARY_REGION")
+    else
+      "local"
+    end
   end
 
   @doc """
@@ -19,7 +31,11 @@ defmodule Fly do
   """
   @spec my_region() :: String.t()
   def my_region do
-    System.fetch_env!("FLY_REGION")
+    if running_in_fly?() do
+      System.fetch_env!("FLY_REGION")
+    else
+      "local"
+    end
   end
 
   @doc """


### PR DESCRIPTION
This sets `FLY_REGION` and `PRIMARY_REGION` to "local" when not running on Fly.io. This is determined by if the `FLY_REGION` environment variable has been set.

I didn't open an issue to discuss beforehand because it was such a small code change, but I think this change will improve developer experience a lot.