### PR TITLE
Default ENV values to "local"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,6 @@ local ETS table for fast access.
 The Fly.io platform already provides and ENV value of `FLY_REGION` which this library accesses.
 
 ```elixir
-Fly.running_in_fly?()
-#=> true
-
 Fly.primary_region()
 #=> "syd"
 
@@ -98,12 +95,12 @@ Fly.rpc_primary(String, :upcase, ["fly"])
 
 ## Local Development
 
-When doing local development, the local and primary regions will be set to "local". However, if you want to simulate running in Fly.io locally, you can set the `FLY_REGION` and `PRIMARY_REGION` environment variables:
+When doing local development, the local and primary regions will be set to "local" by default. However, if you want to simulate running in a non-primary region locally, you can set the `FLY_REGION` and `PRIMARY_REGION` environment variables explicitly:
 
 - `FLY_REGION` - Fly.io tells you which region your app is running in.
-- `PRIMARY_REGION` - You tell Fly.io which region is your "primary".
+- `PRIMARY_REGION` - You tell the library which Fly.io region is your "primary".
 
-When you are running locally, the `FLY_REGION` isn't being set since the app isn't on Fly.io. Also, the `PRIMARY_REGION` set in your `fly.toml` file isn't being used. We just need a way to set those values when the application is running locally.
+When running locally, the `FLY_REGION` isn't set since the app isn't on Fly.io. Also, the `PRIMARY_REGION` set in your `fly.toml` file isn't being used. We just need a way to set those values when the application is running locally.
 
 I like using [direnv](https://direnv.net/) to automatically set and load ENV values when I enter specific directories. Using `direnv`, you can create a file named `.envrc` in your project directory. Add the following lines:
 

--- a/lib/fly.ex
+++ b/lib/fly.ex
@@ -5,36 +5,35 @@ defmodule Fly do
   """
 
   @doc """
-  Returns true if currently running on Fly.io
-  """
-  @spec running_in_fly?() :: boolean()
-  def running_in_fly?() do
-    System.fetch_env("FLY_REGION") != :error
-  end
-
-  @doc """
   Return the configured primary region. Reads and requires an ENV setting for
-  `PRIMARY_REGION`.
+  `PRIMARY_REGION`. If not set, it returns `"local"`.
   """
   @spec primary_region() :: String.t()
   def primary_region do
-    if running_in_fly?() do
-      System.fetch_env!("PRIMARY_REGION")
-    else
-      "local"
+    case System.fetch_env("PRIMARY_REGION") do
+      {:ok, region} ->
+        region
+
+      :error ->
+        System.put_env("PRIMARY_REGION", "local")
+        "local"
     end
   end
 
   @doc """
   Return the configured current region. Reads the `FLY_REGION` ENV setting
-  that's available when deployed on the Fly.io platform.
+  that's available when deployed on the Fly.io platform. If not set, it returns
+  `"local"`.
   """
   @spec my_region() :: String.t()
   def my_region do
-    if running_in_fly?() do
-      System.fetch_env!("FLY_REGION")
-    else
-      "local"
+    case System.fetch_env("FLY_REGION") do
+      {:ok, region} ->
+        region
+
+      :error ->
+        System.put_env("FLY_REGION", "local")
+        "local"
     end
   end
 

--- a/test/fly_test.exs
+++ b/test/fly_test.exs
@@ -1,0 +1,32 @@
+defmodule FlyTest do
+  # Manipulates System ENV settings, don't run async
+  use ExUnit.Case, async: false
+
+  doctest Fly
+
+  describe "primary_region/0" do
+    test "when no primary set, sets to local" do
+      System.delete_env("PRIMARY_REGION")
+      assert "local" == Fly.primary_region()
+      assert "local" == System.fetch_env!("PRIMARY_REGION")
+    end
+
+    test "returns ENV for PRIMARY_REGION when set" do
+      System.put_env("PRIMARY_REGION", "abc")
+      assert "abc" == Fly.primary_region()
+    end
+  end
+
+  describe "my_region/0" do
+    test "when no fly set, sets to local" do
+      System.delete_env("FLY_REGION")
+      assert "local" == Fly.my_region()
+      assert "local" == System.fetch_env!("FLY_REGION")
+    end
+
+    test "returns ENV for FLY_REGION when set" do
+      System.put_env("FLY_REGION", "abc")
+      assert "abc" == Fly.my_region()
+    end
+  end
+end


### PR DESCRIPTION
Based on excellent suggestions in PR #5. This just does it a little differently. 

No longer require users to set local ENV settings. Defaults to "local" for PRIMARY_REGION and FLY_REGION if nothing is set.
