### PR TITLE
Support MY_REGION env

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
-export FLY_REGION=xyz
+export MY_REGION=abc
 export PRIMARY_REGION=xyz

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Fly RPC
 
-Helps a clustered Elixir application know what [Fly.io](https:://fly.io) region it is deployed in, if that is the primary region, and provides features for executing a function through RPC (Remote Procedure Call) on another node by specifying the region to run it in.
+Helps a clustered Elixir application know what [Fly.io](https:://fly.io) region it is deployed in, if that is the primary region, and provides features for executing a function through RPC (Remote Procedure Call) on another node by specifying the region to run it in. It is specifically designed to make it easier to execute code in the "primary" region.
+
+This library can be used outside of the [Fly.io](https://fly.io) platform as well. In order to work, the nodes need to be clustered and then set `PRIMARY_REGION` and `MY_REGION` ENV values. Everything else works the same. When running on [Fly.io](https://fly.io), the `FLY_REGION` ENV value provided by the platform is used for `MY_REGION`.
+
+The "primary" region refers to which region your primary, writeable database lives in. Writes to the primary database should ideally be performed from a server running in, or near, the primary region.
 
 [Online Documentation](https://hexdocs.pm/fly_rpc)
 
@@ -12,7 +16,7 @@ by adding `fly_rpc` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:fly_rpc, "~> 0.1.0"}
+    {:fly_rpc, "~> 0.2.0"}
   ]
 end
 ```
@@ -55,13 +59,13 @@ local ETS table for fast access.
 
 ## Usage
 
-The Fly.io platform already provides and ENV value of `FLY_REGION` which this library accesses.
+The Fly.io platform already provides and ENV value of `FLY_REGION` which this library accesses and uses as the `MY_REGION`. When using this library on a platform other than [fly.io](https://fly.io), you can supply the ENV `MY_REGION` to identify what "region" the running instance is in. Think of the value as a text label of however you want to identify where it's running.
 
 ```elixir
 Fly.primary_region()
 #=> "syd"
 
-Fly.current_region()
+Fly.my_region()
 #=> "lax"
 
 Fly.is_primary?()
@@ -95,26 +99,30 @@ Fly.rpc_primary(String, :upcase, ["fly"])
 
 ## Local Development
 
-When doing local development, the local and primary regions will be set to "local" by default. However, if you want to simulate running in a non-primary region locally, you can set the `FLY_REGION` and `PRIMARY_REGION` environment variables explicitly:
+When doing local development, the local and primary regions will be set to "local" by default. However, if we want to simulate running in a non-primary region locally, we can set the `MY_REGION` and `PRIMARY_REGION` environment variables explicitly:
 
-- `FLY_REGION` - Fly.io tells you which region your app is running in.
-- `PRIMARY_REGION` - You tell the library which Fly.io region is your "primary".
+- `MY_REGION` - You tell the library what region it is running in.
+- `PRIMARY_REGION` - You tell the library which region is the "primary".
 
-When running locally, the `FLY_REGION` isn't set since the app isn't on Fly.io. Also, the `PRIMARY_REGION` set in your `fly.toml` file isn't being used. We just need a way to set those values when the application is running locally.
+By default, the value `"local"` is used for the regions. This works perfectly for local development as we are, effectively, the primary anyway.
+
+## Explicitly Set the Region
+
+When running locally and we explicitly want to set the regions, the `MY_REGION` isn't set since the app isn't on Fly.io. Also, the `PRIMARY_REGION` specified in out `fly.toml` file isn't referenced. We just need a way to set those values when the application is running locally.
 
 I like using [direnv](https://direnv.net/) to automatically set and load ENV values when I enter specific directories. Using `direnv`, you can create a file named `.envrc` in your project directory. Add the following lines:
 
 ```
-export FLY_REGION=xyz
+export MY_REGION=xyz
 export PRIMARY_REGION=xyz
 ```
 
-This tells the app that it's running in the primary region. It will connect to the database and perform writes directly.
+This tells the app that it's running in the primary region called "xyz". It will connect to the database and perform writes directly.
 
 Another option is to start you application like this:
 
 ```
-FLY_REGION=xyz PRIMARY_REGION=xyz iex -S mix phx.server
+MY_REGION=xyz PRIMARY_REGION=xyz iex -S mix phx.server
 ```
 
 You can also create a bash script file named `start` and have it perform the above command.
@@ -123,17 +131,37 @@ You can also create a bash script file named `start` and have it perform the abo
 
 ### Prevent temporary outages during deployments
 
-When deploying on Fly.io, a new instance is rolled out before removing the old instance. This creates a period of time where both new and old instances are deployed together. By default, when deploying a Phoenix application, a new BEAM cookie is generated for each deployment. When the new instance rolls out with a new BEAM cookie, the old and new instances will not cluster together. BEAM instances must have the same cookie in order to connect. This is by design.
+When deploying on [Fly.io](https://fly.io), a new instance is rolled out before removing the old instance. This creates a period of time where both new and old instances are deployed together. By default, when deploying a Phoenix application, a new BEAM cookie is generated for each deployment. When the new instance rolls out with a new BEAM cookie, the old and new instances will not cluster together. BEAM instances must have the same cookie in order to connect. This is by design.
 
 This means a newly deployed application running in a secondary region using [fly_postgres](https://github.com/superfly/fly_postgres_elixir) is unable to perform writes to the older application running in the primary region. It is possible for writes to fail during that rollout window.
 
-To prevent this problem, the BEAM cookie can be explicitly set instead of randomly generated for new builds. When explicitly set, the newly deployed application is still able to connect and cluster with the older application running in the primary region.
+To prevent this problem, the BEAM cookie can be explicitly set instead of using a randomly generated one for new builds. When explicitly set, the newly deployed application is still able to connect and cluster with the older application running in the primary region.
 
 Here is a guide to setting a static cookie for your project that is written into the code itself. This is fine to do because the cookie isn't considered a secret used for security.
 
 [fly.io/docs/app-guides/elixir-static-cookie/](https://fly.io/docs/app-guides/elixir-static-cookie/)
 
 When the cookie is static and unchanged from one deployment to the next, then applications can continue to cluster and access the applications running in primary region.
+
+### Where Did My Function Go?
+
+When deploying on [Fly.io](https://fly.io), a new instance is rolled out before removing the old instance. This creates a period of time where both new and old instances are deployed together.
+
+In this scenario, let's assume:
+- Node A is an old node.
+- Node B is a new node.
+
+Node A attempts to execute a function on Node B. Node B contains new code and that function doesn't exist as called. Perhaps the function was renamed, the arity changed, a pattern match changed or it's a new function.
+
+Whatever the reason, we now have a situation where the function we want to call fails because it doesn't exist the way we expect it on the new node in the cluster.
+
+Be aware that this _can_ happen. It may cause a single request to fail and that may be fine. We can take steps in our applications to avoid any interruption if it's a critical function that needs to change.
+
+For critical functions, the following pattern can be used:
+- Create the new, changed function
+- Maintain backward compatibility with another function (if applicable)
+- Deploy the new code moving all instances to use the new, desired function. During the deploy, the backward compatible function prevent breakage.
+- A later deploy removes the backward compatible function.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ By default, the value `"local"` is used for the regions. This works perfectly fo
 
 ## Explicitly Set the Region
 
-When running locally and we explicitly want to set the regions, the `MY_REGION` isn't set since the app isn't on Fly.io. Also, the `PRIMARY_REGION` specified in out `fly.toml` file isn't referenced. We just need a way to set those values when the application is running locally.
+When running locally and we explicitly want to set the regions, the `MY_REGION` isn't set since the app isn't on Fly.io. Also, the `PRIMARY_REGION` specified in our `fly.toml` file isn't referenced. We just need a way to set those values when the application is running locally.
 
 I like using [direnv](https://direnv.net/) to automatically set and load ENV values when I enter specific directories. Using `direnv`, you can create a file named `.envrc` in your project directory. Add the following lines:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -9,13 +9,13 @@ Start multiple nodes locally on the same developer machine. Multiple nodes can b
 Node 1 - Primary Region:
 
 ```shell
-FLY_REGION=xyz PRIMARY_REGION=xyz iex --name node1@127.0.0.1 -S mix
+MY_REGION=xyz PRIMARY_REGION=xyz iex --name node1@127.0.0.1 -S mix
 ```
 
 Node 2 - Non-Primary Region:
 
 ```shell
-FLY_REGION=abc PRIMARY_REGION=xyz iex --name node2@127.0.0.1 -S mix
+MY_REGION=abc PRIMARY_REGION=xyz iex --name node2@127.0.0.1 -S mix
 ```
 
 In the IEx shell, run this command to connect `node2` to `node1`.
@@ -30,3 +30,15 @@ The following command verifies the nodes are connected by showing the other conn
 Node.list
 ```
 
+The nodes are now verified as connected. Commands can be executed from either node to the other.
+
+NOTE: If running the test on the library itself, it won't work because the GenServer must be started first. Testing the library as part of another application is easier as the functions to execute on the other node are present and the GenServer will have started with the Application supervision tree. To start the GenServer manually in each node, execute: `Fly.RPC.start_link([])`
+
+Example:
+
+```elixir
+Fly.rpc_primary(String, :upcase, ["fly"])
+#=> "FLY"
+```
+
+Additional nodes can be started similarly with additional regions for testing.

--- a/lib/fly.ex
+++ b/lib/fly.ex
@@ -22,18 +22,23 @@ defmodule Fly do
 
   @doc """
   Return the configured current region. Reads the `FLY_REGION` ENV setting
-  that's available when deployed on the Fly.io platform. If not set, it returns
-  `"local"`.
+  available when deployed on the Fly.io platform. When running on a different
+  platform, that ENV value will not be set. Setting the `MY_REGION` ENV value
+  instructs the node how to identify what "region" it is in. If not set, it
+  returns `"local"`.
+
+  The value itself is not important. If the value matches the value for the
+  `PRIMARY_REGION` then it behaves as though it is the primary.
   """
   @spec my_region() :: String.t()
   def my_region do
-    case System.fetch_env("FLY_REGION") do
-      {:ok, region} ->
-        region
-
-      :error ->
-        System.put_env("FLY_REGION", "local")
+    case System.get_env("FLY_REGION") || System.get_env("MY_REGION") do
+      nil ->
+        System.put_env("MY_REGION", "local")
         "local"
+
+      region ->
+        region
     end
   end
 

--- a/lib/fly_rpc.ex
+++ b/lib/fly_rpc.ex
@@ -168,7 +168,7 @@ defmodule Fly.RPC do
   """
   @spec is_rpc_supported?(node) :: boolean()
   def is_rpc_supported?(node) do
-    # note: use :erpc.call once erlang 23+ is reauired
+    # note: use :erpc.call once erlang 23+ is required
     case :rpc.call(node, Kernel, :function_exported?, [Fly, :my_region, 0], 5000) do
       result when is_boolean(result) ->
         result

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Fly.MixProject do
   def project do
     [
       app: :fly_rpc,
-      version: "0.1.6",
+      version: "0.2.0",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       name: "Fly RPC",
@@ -33,7 +33,7 @@ defmodule Fly.MixProject do
 
   defp description do
     """
-    Library for making RPC calls to nodes in other Fly.io regions.
+    Library for making RPC calls to nodes in other fly.io regions. Specifically designed to make it easier to execute code in the "primary" region.
     """
   end
 

--- a/test/fly_test.exs
+++ b/test/fly_test.exs
@@ -6,7 +6,7 @@ defmodule FlyTest do
 
   describe "primary_region/0" do
     test "when no primary set, sets to local" do
-      System.delete_env("PRIMARY_REGION")
+      delete_env_if_present("PRIMARY_REGION")
       assert "local" == Fly.primary_region()
       assert "local" == System.fetch_env!("PRIMARY_REGION")
     end
@@ -18,15 +18,29 @@ defmodule FlyTest do
   end
 
   describe "my_region/0" do
-    test "when no fly set, sets to local" do
-      System.delete_env("FLY_REGION")
+    test "when no FLY_REGION set, use MY_REGION" do
+      delete_env_if_present("FLY_REGION")
+      System.put_env("MY_REGION", "custom")
+      assert "custom" == Fly.my_region()
+      assert "custom" == System.fetch_env!("MY_REGION")
+    end
+
+    test "when no FLY_REGION and no MY_REGION set, sets to local" do
+      delete_env_if_present("FLY_REGION")
+      delete_env_if_present("MY_REGION")
       assert "local" == Fly.my_region()
-      assert "local" == System.fetch_env!("FLY_REGION")
+      assert "local" == System.fetch_env!("MY_REGION")
     end
 
     test "returns ENV for FLY_REGION when set" do
       System.put_env("FLY_REGION", "abc")
       assert "abc" == Fly.my_region()
+    end
+  end
+
+  defp delete_env_if_present(varname) do
+    if System.get_env(varname) do
+      System.delete_env(varname)
     end
   end
 end


### PR DESCRIPTION
Support using the `MY_REGION` ENV value for explicitly setting the region to report for the running application. 

This is helpful for local testing with different regions but unnecessary when used on the Fly.io platform. On Fly.io, it looks for the `FLY_REGION` to determine the region being run in.